### PR TITLE
Enforce fail-fast behavior in entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 readonly keyboard="$1"
 readonly keymap="$2"
 readonly qmk_output="$3"


### PR DESCRIPTION
If the qmk compile process fails, the firmware build action will not fail without enforcing the exit immediately flag.