### PR TITLE
Add CONVERT_TO Controller support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,15 @@ jobs:
           keyboard: dztech/dz65rgb/v3
           keymap: testing-keymap
           local-keymap-path: test/keymaps/testing-keymap
+
+  build-helios:
+    name: Build Corne for Helios
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./
+        with:
+          keyboard: crkbd/rev1
+          keymap: default
+          controller: helios

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Build QMK firmware for your keyboard using your keymap with GitHub Actions.
 |:--------------------|:---------------------------------------------------------------|:---------|:-------------|
 | `keyboard`          | The target keyboard for this firmware build                    | Yes      |              |
 | `keymap`            | The keymap to build for this firmware                          | Yes      | `default`    |
+| `controller`        | The controller to build for this firmware                      | No       |              |
 | `local-keymap-path` | Path to a local keymap directory to inject into the QMK home   | No       | ` `          |
 | `output-dir`        | Directory in the workspace where built firmware will be placed | No       | `qmk-output` |
 
@@ -36,6 +37,7 @@ jobs:
         with:
           keyboard: dztech/dz65rgb/v3
           keymap: my-keymap
+          controller: helios
           local-keymap-path: keymaps/my-keymap
           output-dir: qmk-firmware-to-be-flashed
 

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,9 @@ inputs:
     description: The keymap to build for this firmware
     required: true
     default: default
+  controller:
+    description: The controller to build for this firmware
+    required: false
   local-keymap-path:
     description: Path to a local keymap directory to inject into the QMK home
     default: ""
@@ -31,5 +34,6 @@ runs:
   args:
     - ${{ inputs.keyboard }}
     - ${{ inputs.keymap }}
+    - ${{ inputs.controller }}
     - ${{ inputs.output-dir }}
     - ${{ inputs.local-keymap-path }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,8 +4,17 @@ set -e
 
 readonly keyboard="$1"
 readonly keymap="$2"
-readonly qmk_output="$3"
-readonly local_keymap="$4"
+readonly controller="$3"
+readonly qmk_output="$4"
+readonly local_keymap="$5"
+
+# Check if the controller matches one of the available options
+if [ "$controller" ]; then
+  if [ "$controller" != "proton_c" ] && [ "$controller" != "kb2040" ] && [ "$controller" != "promicro_rp2040" ] && [ "$controller" != "blok" ] && [ "$controller" != "bit_c_pro" ] && [ "$controller" != "stemcell" ] && [ "$controller" != "bonsai_c4" ] && [ "$controller" != "rp2040_ce" ] && [ "$controller" != "elite_pi" ] && [ "$controller" != "helios" ] && [ "$controller" != "liatris" ] && [ "$controller" != "imera" ] && [ "$controller" != "michi" ]; then
+    echo "Invalid convert option $keyboard"
+    exit 1
+  fi
+fi
 
 # Find the keymaps directory the same way QMK CLI does
 if [ -n "$local_keymap" ]; then
@@ -25,10 +34,11 @@ if [ -n "$local_keymap" ]; then
 fi
 
 qmk config user.qmk_home=/opt/qmk_firmware
-qmk compile -kb "$keyboard" -km "$keymap"
+echo Controller - "$controller"
+qmk compile -kb "$keyboard" -km "$keymap" ${controller:+-e CONVERT_TO="$controller"}
 
 mkdir "$qmk_output"
-find "/opt/qmk_firmware/.build" \( -name '*.hex' -or -name '*.bin' \) -exec cp -v {} "$qmk_output" \;
+find "/opt/qmk_firmware/.build" \( -name '*.hex' -or -name '*.bin' -or -name '*.uf2' \) -exec cp -v {} "$qmk_output" \;
 
 echo "built-images=$(find "$qmk_output" -type f | sed "s|^$qmk_output||" | paste -sd ',')" \
   >> "$GITHUB_OUTPUT"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,14 +8,6 @@ readonly controller="$3"
 readonly qmk_output="$4"
 readonly local_keymap="$5"
 
-# Check if the controller matches one of the available options
-if [ "$controller" ]; then
-  if [ "$controller" != "proton_c" ] && [ "$controller" != "kb2040" ] && [ "$controller" != "promicro_rp2040" ] && [ "$controller" != "blok" ] && [ "$controller" != "bit_c_pro" ] && [ "$controller" != "stemcell" ] && [ "$controller" != "bonsai_c4" ] && [ "$controller" != "rp2040_ce" ] && [ "$controller" != "elite_pi" ] && [ "$controller" != "helios" ] && [ "$controller" != "liatris" ] && [ "$controller" != "imera" ] && [ "$controller" != "michi" ]; then
-    echo "Invalid convert option $keyboard"
-    exit 1
-  fi
-fi
-
 # Find the keymaps directory the same way QMK CLI does
 if [ -n "$local_keymap" ]; then
   keymap_lookup_dir="/opt/qmk_firmware/keyboards/$keyboard"
@@ -34,7 +26,6 @@ if [ -n "$local_keymap" ]; then
 fi
 
 qmk config user.qmk_home=/opt/qmk_firmware
-echo Controller - "$controller"
 qmk compile -kb "$keyboard" -km "$keymap" ${controller:+-e CONVERT_TO="$controller"}
 
 mkdir "$qmk_output"


### PR DESCRIPTION
This PR adds the ability to convert the firmware to a supported controller as listed here [QMK Converters](https://github.com/qmk/qmk_firmware/blob/master/docs/feature_converters.md#supported-converters)

This is not a required option but if provided will output the correct .uf2 file for the rp2040 based controllers.

I also added an additional test just using the existing Corne keyboard.